### PR TITLE
Add generated assets to main compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ dist
 
 # Other temporary files
 tmp/
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -27,6 +27,11 @@
     "format": "prettier -w src test",
     "lint": "eslint src test",
     "test": "c8 --reporter=text --reporter=html tap --reporter=spec --no-coverage test/*.test.js && npm run test:types",
+    "test:index": "c8 --reporter=text --reporter=html tap --reporter=spec --no-coverage test/index.test.js && npm run test:types",
+    "test:dev": "c8 --reporter=text --reporter=html tap --reporter=spec --no-coverage test/development-mode.test.js && npm run test:types",
+    "test:cache": "c8 --reporter=text --reporter=html tap --reporter=spec --no-coverage test/cached-build.test.js && npm run test:types",
+    "test:explicit": "c8 --reporter=text --reporter=html tap --reporter=spec --no-coverage test/explicit-import.test.js && npm run test:types",
+    "test:clean": "c8 --reporter=text --reporter=html tap --reporter=spec --no-coverage test/clean-plugin.test.js && npm run test:types",
     "test:watch": "tap --watch --reporter=spec --no-browser --coverage-report=text --coverage-report=html test/*.test.js",
     "test:ci": "c8 --reporter=text --reporter=json --check-coverage --branches 90 --functions 90 --lines 90 --statements 90 tap --no-color --no-coverage test/*.test.js && npm run test:types",
     "test:types": "tsd",
@@ -35,10 +40,12 @@
     "postpublish": "git push origin && git push origin -f --tags"
   },
   "dependencies": {
+    "memfs": "^3.4.12",
     "webpack": "^5.61.0"
   },
   "devDependencies": {
     "c8": "^7.10.0",
+    "clean-webpack-plugin": "^4.0.0",
     "eslint": "^7.12.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.25.2",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,10 @@
-import { Compiler, WebpackPluginInstance } from 'webpack';
+import { Compiler, WebpackPluginInstance } from 'webpack'
 
-export const banner: string;
-export const footer: string;
+export const banner: string
+export const footer: string
 
 export class PinoWebpackPlugin implements WebpackPluginInstance {
-  constructor(options: {transports: string[]});
-  [index: string]: any;
-  apply: (compiler: Compiler) => void;
+  constructor(options: { transports: string[] })
+  [index: string]: any
+  apply: (compiler: Compiler) => void
 }

--- a/src/index.js
+++ b/src/index.js
@@ -66,10 +66,9 @@ class PinoWebpackPlugin {
               this.addCompatibilityFooter.bind(this)
             )
             // Add child compilation assets to the main compilation
-            compilation.hooks.additionalAssets.tapAsync(
-              'PinoWebpackPlugin',
-              (compilation.assets = Object.assign(childCompilation.assets, compilation.assets))
-            )
+            compilation.hooks.additionalAssets.tapAsync('PinoWebpackPlugin', () => {
+              compilation.assets = Object.assign(childCompilation.assets, compilation.assets)
+            })
           })
 
           // Perform the compilation and then track each generated file relative path

--- a/src/index.js
+++ b/src/index.js
@@ -84,8 +84,11 @@ class PinoWebpackPlugin {
           Object.values(dependencies).map((worker) => worker.entry)
         )
         childCompiler.inputFileSystem = compiler.inputFileSystem
-        // Generate files in memory
-        // It will be written to output path by main compilation
+        // Generate files without footer in memory
+        // to be written with footer to output path by main compilation
+        // __
+        // If the child compiler would write to file system,
+        // we would have to manually handle the footer-less file deletion
         childCompiler.outputFileSystem = fs
 
         // Enable required plugins

--- a/src/index.js
+++ b/src/index.js
@@ -65,6 +65,11 @@ class PinoWebpackPlugin {
               },
               this.addCompatibilityFooter.bind(this)
             )
+            // Add child compilation assets to the main compilation
+            compilation.hooks.additionalAssets.tapAsync(
+              'PinoWebpackPlugin',
+              (compilation.assets = Object.assign(childCompilation.assets, compilation.assets))
+            )
           })
 
           // Perform the compilation and then track each generated file relative path

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 const webpack = require('webpack')
 const CommonJsRequireDependency = require('webpack/lib/dependencies/CommonJsRequireDependency')
+const { createFsFromVolume, Volume } = require('memfs')
+const { sep, dirname, relative } = require('path')
+const { cache } = require('webpack')
 
-const { sep } = require('path')
-
-const banner = `/* Start of pino-webpack-plugin additions */
+const fileBanner = `/* Start of pino-webpack-plugin additions */
 function pinoWebpackAbsolutePath(p) {
   try {
     return require('path').join(__dirname, p)
@@ -15,12 +16,14 @@ function pinoWebpackAbsolutePath(p) {
 }
 `
 
-const footer = `
+const compatibilityFooter = `
 /* The following statement is added by pino-webpack-plugin to make sure extracted file are valid commonjs modules */
 ; if(typeof module !== 'undefined' && typeof __webpack_exports__ !== "undefined") { module.exports = __webpack_exports__; }
 `
-
+const PLUGIN_NAME = 'PinoWebpackPlugin'
 const CACHE_ID = 'pino-worker-plugin'
+
+const fs = createFsFromVolume(new Volume())
 
 class PinoWebpackPlugin {
   constructor(options) {
@@ -29,212 +32,143 @@ class PinoWebpackPlugin {
   }
 
   apply(compiler) {
-    compiler.hooks.thisCompilation.tap('PinoWebpackPlugin', (compilation) => {
-      const generatedPaths = {}
-      const workers = {}
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      const dependencies = {} // {entry: source file, file: generated file}
 
       // When requiring pino, thread-stream or users transports, prepare some required files for external bundling.
-      compilation.hooks.buildModule.tap('PinoWebpackPlugin', this.trackInclusions.bind(this, workers))
+      compilation.hooks.buildModule.tap(PLUGIN_NAME, (mod) => {
+        const addChildCompilerEntryPoint = (id, context, file, name) => {
+          // Use id as name if none was given
+          dependencies[id] = { entry: new webpack.EntryPlugin(context, file, { name: name ?? id }) }
+        }
+
+        switch (true) {
+          case mod.rawRequest === 'thread-stream':
+            addChildCompilerEntryPoint('thread-stream-worker', mod.context, './lib/worker.js')
+            break
+
+          case mod.rawRequest === 'pino':
+            addChildCompilerEntryPoint('pino/file', mod.context, './file.js', 'pino-file')
+            addChildCompilerEntryPoint('pino-worker', mod.context, './lib/worker.js')
+            addChildCompilerEntryPoint('pino-pipeline-worker', mod.context, './lib/worker-pipeline.js')
+            break
+
+          case this.transports.includes(mod.rawRequest):
+            addChildCompilerEntryPoint(mod.rawRequest, mod.context, mod.request)
+            break
+        }
+      })
 
       // When requiring pino, also make sure all transports in the options are required
-      compilation.hooks.succeedModule.tap('PinoWebpackPlugin', (mod) => {
-        if (mod.rawRequest !== 'pino') {
-          return
-        }
+      compilation.hooks.succeedModule.tap(PLUGIN_NAME, (mod) => {
+        if (mod.rawRequest !== 'pino') return
 
         for (const transport of this.transports) {
           mod.dependencies.push(new CommonJsRequireDependency(transport, null))
         }
       })
 
-      // When webpack has finished analyzing and bundling all files, compile marked external files
-      compilation.hooks.processAssets.tapAsync(
-        {
-          name: 'PinoWebpackPlugin',
-          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
-        },
-        (assets, callback) => {
-          const childCompiler = this.createChildCompiler(compiler, compilation, workers)
-
-          // When the files have been compiled, add a compatibility footer
-          childCompiler.hooks.thisCompilation.tap('PinoWebpackPlugin', (childCompilation) => {
-            childCompilation.hooks.processAssets.tapAsync(
-              {
-                name: 'PinoWebpackPlugin',
-                stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
-              },
-              this.addCompatibilityFooter.bind(this)
-            )
-            // Add child compilation assets to the main compilation
-            compilation.hooks.additionalAssets.tapAsync('PinoWebpackPlugin', () => {
-              compilation.assets = Object.assign(childCompilation.assets, compilation.assets)
-            })
-          })
-
-          // Perform the compilation and then track each generated file relative path
-          childCompiler.run((err, stats) => {
-            /* c8 ignore next 3 */
-            if (err) {
-              return callback(err)
-            }
-
-            for (const id of Object.keys(workers)) {
-              generatedPaths[id] = this.getGeneratedFile(stats.compilation, id)
-            }
-
-            this.handleCache(compiler, generatedPaths, callback)
-          })
-        }
-      )
-
-      compilation.hooks.processAssets.tapAsync(
-        {
-          name: 'PinoWebpackPlugin',
-          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL
-        },
-        this.addExternalFilesBanner.bind(this, generatedPaths)
-      )
-    })
-  }
-
-  handleCache(compiler, generatedPaths, callback) {
-    // reference for cache https://github.com/webpack/webpack/blob/dc70535ef859e517e8659f87ca37f33261ad9092/lib/Cache.js
-    const cache = compiler.getCache(CACHE_ID)
-
-    // With this trick we are filling the missing entries to the generatedPaths
-    // caused by the fact that the Webpack Cache is enabled
-    // we are not invalidating cache because we are only filling what's missing
-    cache.get(CACHE_ID, CACHE_ID, (err, data = {}) => {
-      /* c8 ignore next 3 */
-      if (err) {
-        return callback(err)
-      }
-
-      for (const [id, fileName] of Object.entries(data)) {
-        if (!generatedPaths[id]) {
-          generatedPaths[id] = fileName
-        }
-      }
-
-      cache.store(CACHE_ID, CACHE_ID, generatedPaths, callback)
-    })
-  }
-
-  trackInclusions(workers, mod) {
-    if (mod.rawRequest === 'thread-stream') {
-      this.addExternalFile(workers, mod, 'thread-stream-worker', './lib/worker.js')
-    } else if (mod.rawRequest === 'pino') {
-      this.addExternalFile(workers, mod, 'pino/file', './file.js', 'pino-file')
-      this.addExternalFile(workers, mod, 'pino-worker', './lib/worker.js')
-      this.addExternalFile(workers, mod, 'pino-pipeline-worker', './lib/worker-pipeline.js')
-    } else if (this.transports.includes(mod.rawRequest)) {
-      workers[mod.rawRequest] = new webpack.EntryPlugin(mod.context, mod.request, {
-        name: mod.rawRequest
-      })
-    }
-  }
-
-  addExternalFile(workers, mod, id, file, name) {
-    if (!name) {
-      name = id
-    }
-
-    workers[id] = new webpack.EntryPlugin(mod.context, file, { name })
-  }
-
-  getGeneratedFile(compilation, name) {
-    if (name === 'pino/file') {
-      name = 'pino-file'
-    }
-
-    const assets = compilation.entrypoints.get(name)
-
-    /* c8 ignore next 3 */
-    if (!assets) {
-      return ''
-    }
-
-    const files = assets.getFiles() || /* c8 ignore next */ []
-
-    return files[0] || /* c8 ignore next */ ''
-  }
-
-  createChildCompiler(compiler, compilation, workers) {
-    // Create the compiler
-    const childCompiler = compilation.createChildCompiler(
-      'PinoWebpackPlugin',
-      {
-        library: {
-          type: 'commonjs2'
-        },
-        iife: false
-      },
-      Object.values(workers)
-    )
-    childCompiler.inputFileSystem = compiler.inputFileSystem
-    childCompiler.outputFileSystem = compiler.outputFileSystem
-
-    // Enable required plugins
-    new webpack.node.NodeTemplatePlugin({
-      library: {
-        type: 'commonjs2'
-      },
-      iife: false
-    }).apply(childCompiler)
-    new webpack.node.NodeTargetPlugin().apply(childCompiler)
-
-    return childCompiler
-  }
-
-  addExternalFilesBanner(generatedPaths, assets, callback) {
-    for (const path of Object.keys(assets)) {
-      if (path.endsWith('.js')) {
-        /*
-          Find how much the asset is nested:
-            * First of all we split the asset directory in the different levels
-            * Each level means is then replaced with ".." as our external files are in the root of the build folder.
-            * If no component was present, then it means the asset is root of the builder as well, so we just use ".".
-        */
-        const prefix =
-          path
-            .split(sep)
-            .slice(0, -1)
-            .map(() => '..')
-            .join(sep) || '.'
-
-        /*
-          Create the __bundlerPathsOverrides variable by mapping each generatedPath to its relative location.
-          We use a injected function to derive the absolute path at runtime.
-        */
-        const declarations = Object.entries(generatedPaths)
-          .map(([id, path]) => `'${id}': pinoWebpackAbsolutePath('${prefix}${sep}${path}')`)
-          .join(',')
-
-        // Prepend the banner and the __bundlerPathsOverrides to the generated file.
-        assets[path] = new webpack.sources.ConcatSource(
-          banner,
-          `\nglobalThis.__bundlerPathsOverrides = {${declarations}};\n/* End of pino-webpack-plugin additions */\n\n`,
-          assets[path]
+      /** Compile dependencies and add result to compilation assets **/
+      compilation.hooks.additionalAssets.tapAsync(PLUGIN_NAME, (processAssetsCallback) => {
+        // Create child compiler for dependencies
+        const childCompiler = compilation.createChildCompiler(
+          `${PLUGIN_NAME}ChildCompiler`,
+          {
+            library: {
+              type: 'commonjs2'
+            },
+            iife: false
+          },
+          Object.values(dependencies).map((worker) => worker.entry)
         )
-      }
-    }
+        childCompiler.inputFileSystem = compiler.inputFileSystem
+        // Generate files in memory
+        // It will be written to output path by main compilation
+        childCompiler.outputFileSystem = fs
 
-    callback()
-  }
+        // Enable required plugins
+        new webpack.node.NodeTemplatePlugin({
+          library: {
+            type: 'commonjs2'
+          },
+          iife: false
+        }).apply(childCompiler)
+        new webpack.node.NodeTargetPlugin().apply(childCompiler)
 
-  addCompatibilityFooter(childAssets, childCallback) {
-    for (const path of Object.keys(childAssets)) {
-      if (path.endsWith('.js')) {
-        childAssets[path] = new webpack.sources.ConcatSource(childAssets[path], footer)
-      }
-    }
+        // When the files have been compiled, add a compatibility footer
+        childCompiler.hooks.thisCompilation.tap(PLUGIN_NAME, (childCompilation) => {
+          // Add assets with compatibility footer to main compilation
+          childCompilation.hooks.processAssets.tap(
+            {
+              name: `${PLUGIN_NAME}ChildCompiler`,
+              stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+            },
+            (childAssets) => {
+              for (const path of Object.keys(childAssets)) {
+                if (path.endsWith('.js')) {
+                  compilation.emitAsset(path, new webpack.sources.ConcatSource(childAssets[path], compatibilityFooter))
+                }
+              }
+            }
+          )
 
-    childCallback()
+          // Get generated file for each dependency
+          childCompilation.hooks.chunkAsset.tap(`${PLUGIN_NAME}ChildCompiler`, (chunk, file) => {
+            const dependencyId = chunk.name === 'pino-file' ? 'pino/file' : chunk.name
+            if (dependencyId && dependencies[dependencyId]) {
+              dependencies[dependencyId].file = file
+            }
+          })
+        })
+
+        // Perform the dependencies compilation
+        childCompiler.run((err, stats) => {
+          processAssetsCallback(err, stats)
+        })
+      })
+
+      // Add banner to entrypoints files
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS
+        },
+        () => {
+          const workerFiles = []
+
+          // Create array of declarations used in banner
+          for (const depId in dependencies) {
+            if (!dependencies[depId].file) continue
+            workerFiles.push([depId, dependencies[depId].file])
+          }
+
+          compilation.entrypoints.forEach((ep, k) => {
+            for (const entrypointFile of ep.getFiles()) {
+              const relativePath = relative(dirname(entrypointFile), '.') || '.'
+              compilation.updateAsset(
+                entrypointFile,
+                new webpack.sources.ConcatSource(
+                  fileBanner,
+                  '\n',
+                  `globalThis.__bundlerPathsOverrides = {${workerFiles.map(
+                    ([workerId, file]) => `'${workerId}': pinoWebpackAbsolutePath('${relativePath}${sep}${file}')`
+                  )}};`,
+                  '\n',
+                  '/* End of pino-webpack-plugin additions */',
+                  '\n\n',
+                  compilation.assets[entrypointFile]
+                )
+              )
+            }
+          })
+        }
+      )
+    })
   }
 }
 
 module.exports = {
-  banner,
-  footer,
+  banner: fileBanner,
+  footer: compatibilityFooter,
   PinoWebpackPlugin
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ const webpack = require('webpack')
 const CommonJsRequireDependency = require('webpack/lib/dependencies/CommonJsRequireDependency')
 const { createFsFromVolume, Volume } = require('memfs')
 const { sep, dirname, relative } = require('path')
-const { cache } = require('webpack')
+// const { cache } = require('webpack') // Cache handling missing
 
 const fileBanner = `/* Start of pino-webpack-plugin additions */
 function pinoWebpackAbsolutePath(p) {
@@ -21,7 +21,7 @@ const compatibilityFooter = `
 ; if(typeof module !== 'undefined' && typeof __webpack_exports__ !== "undefined") { module.exports = __webpack_exports__; }
 `
 const PLUGIN_NAME = 'PinoWebpackPlugin'
-const CACHE_ID = 'pino-worker-plugin'
+// const CACHE_ID = 'pino-worker-plugin' // Cache handling missing
 
 const fs = createFsFromVolume(new Volume())
 
@@ -61,7 +61,9 @@ class PinoWebpackPlugin {
 
       // When requiring pino, also make sure all transports in the options are required
       compilation.hooks.succeedModule.tap(PLUGIN_NAME, (mod) => {
-        if (mod.rawRequest !== 'pino') return
+        if (mod.rawRequest !== 'pino') {
+          return
+        }
 
         for (const transport of this.transports) {
           mod.dependencies.push(new CommonJsRequireDependency(transport, null))
@@ -138,7 +140,9 @@ class PinoWebpackPlugin {
 
           // Create array of declarations used in banner
           for (const depId in dependencies) {
-            if (!dependencies[depId].file) continue
+            if (!dependencies[depId].file) {
+              continue
+            }
             workerFiles.push([depId, dependencies[depId].file])
           }
 

--- a/test/clean-plugin.test.js
+++ b/test/clean-plugin.test.js
@@ -1,0 +1,89 @@
+'use strict'
+
+const { readFileSync, readdirSync } = require('fs')
+const { resolve } = require('path')
+const { test } = require('tap')
+const webpack = require('webpack')
+const { banner, footer, PinoWebpackPlugin } = require('../src/index')
+const { CleanWebpackPlugin } = require('clean-webpack-plugin')
+const execa = require('execa')
+
+test('it should correctly generated all required pino files', (t) => {
+  t.plan(20)
+
+  const distFolder = t.testdir()
+
+  webpack(
+    {
+      context: resolve(__dirname, 'fixtures'),
+      mode: 'production',
+      target: 'node',
+      entry: {
+        first: './first.js',
+        'abc/cde/second': './second.js'
+      },
+      output: {
+        path: distFolder,
+        filename: '[name]-[contenthash].js'
+      },
+      plugins: [new CleanWebpackPlugin(), new PinoWebpackPlugin({ transports: ['pino-pretty'] })],
+      optimization: {
+        minimize: false
+      }
+    },
+    (err, stats) => {
+      t.error(err)
+      t.notOk(stats.hasErrors())
+
+      // Find all files in the folder
+      const rootFiles = readdirSync(distFolder).filter((e) => e.endsWith('.js'))
+      const nestedFiles = readdirSync(resolve(distFolder, 'abc/cde')).filter((e) => e.endsWith('.js'))
+
+      const firstFile = rootFiles.find((e) => e.startsWith('first-'))
+      const secondFile = nestedFiles.find((e) => e.startsWith('second-'))
+      const threadStream = rootFiles.find((e) => e.startsWith('thread-stream-'))
+      const pinoWorker = rootFiles.find((e) => e.startsWith('pino-worker-'))
+      const pinoPipelineWorker = rootFiles.find((e) => e.startsWith('pino-pipeline-worker-'))
+      const pinoFile = rootFiles.find((e) => e.startsWith('pino-file-'))
+      const pinoPretty = rootFiles.find((e) => e.startsWith('pino-pretty-'))
+
+      // Check that all required files have been generated
+      t.ok(firstFile)
+      t.ok(secondFile)
+      t.ok(threadStream)
+      t.ok(pinoWorker)
+      t.ok(pinoPipelineWorker)
+      t.ok(pinoFile)
+      t.ok(pinoPretty)
+
+      // Check that generated pino related files have the right footer
+      for (const file of [threadStream, pinoWorker, pinoPipelineWorker, pinoFile, pinoPretty]) {
+        t.ok(readFileSync(resolve(distFolder, file), 'utf-8').endsWith(footer))
+      }
+
+      // Check that the root file starts with the banner and has the right path to pino-file
+      const firstContent = readFileSync(resolve(distFolder, firstFile), 'utf-8')
+      t.ok(firstContent.startsWith(banner))
+      t.ok(
+        firstContent.includes(
+          `globalThis.__bundlerPathsOverrides = {'pino/file': pinoWebpackAbsolutePath('./${pinoFile}')`
+        )
+      )
+
+      execa(process.argv[0], [resolve(distFolder, firstFile)]).then(({ stdout }) => {
+        t.match(stdout, /This is first!/)
+      })
+
+      const secondDistFilePath = resolve(distFolder, `abc/cde/${secondFile}`)
+
+      // Check that the root file starts with the banner and has the right path to pino-file
+      const secondContent = readFileSync(secondDistFilePath, 'utf-8')
+      t.ok(secondContent.startsWith(banner))
+      t.ok(secondContent.includes(`'pino-pretty': pinoWebpackAbsolutePath('../../${pinoPretty}')`))
+
+      execa(process.argv[0], [resolve(secondDistFilePath)]).then(({ stdout }) => {
+        t.match(stdout, /This is second!/)
+      })
+    }
+  )
+})

--- a/test/explicit-import.test.js
+++ b/test/explicit-import.test.js
@@ -7,7 +7,7 @@ const webpack = require('webpack')
 const { banner, footer, PinoWebpackPlugin } = require('../src/index')
 const execa = require('execa')
 
-test('it should correctly generated all required pino files whe using explicit import', (t) => {
+test('it should correctly generated all required pino files when using explicit import', (t) => {
   t.plan(16)
 
   const distFolder = t.testdir()

--- a/test/explicit-import.test.js
+++ b/test/explicit-import.test.js
@@ -7,7 +7,7 @@ const webpack = require('webpack')
 const { banner, footer, PinoWebpackPlugin } = require('../src/index')
 const execa = require('execa')
 
-test('it should correctly generated all required pino files', (t) => {
+test('it should correctly generated all required pino files whe using explicit import', (t) => {
   t.plan(16)
 
   const distFolder = t.testdir()

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -1,9 +1,11 @@
-import { expectType } from "tsd";
-import { WebpackPluginInstance } from "webpack";
-import { PinoWebpackPlugin, banner, footer } from "../..";
+import { expectType } from 'tsd'
+import { WebpackPluginInstance } from 'webpack'
+import { PinoWebpackPlugin, banner, footer } from '../..'
 
-expectType<WebpackPluginInstance>(new PinoWebpackPlugin({
-  transports: ['pino-pretty'],
-}));
-expectType<string>(banner);
-expectType<string>(footer);
+expectType<WebpackPluginInstance>(
+  new PinoWebpackPlugin({
+    transports: ['pino-pretty']
+  })
+)
+expectType<string>(banner)
+expectType<string>(footer)


### PR DESCRIPTION
The assets generated by childCompilation (basically the JS files) are now added to the main compilation assets, allowing other Webpack plugins to be aware of it.

FIXES: #58