### PR TITLE
fix: upgrade pino pretty to v9.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-promise": "^5.1.1",
     "execa": "^5.0.0",
     "pino": "^8.0.0",
-    "pino-pretty": "^8.0.0",
+    "pino-pretty": "^9.1.1",
     "prettier": "^2.4.1",
     "tap": "^16.0.0",
     "tsd": "^0.24.1"


### PR DESCRIPTION
This PR forces the upgrade of pino-pretty to v9.1.1, resolving the problems discussed in https://github.com/pinojs/pino-webpack-plugin/pull/54

Closes https://github.com/pinojs/pino-webpack-plugin/pull/54

cc: @simoneb 