### PR TITLE
fix!: Declare webpack as the peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "postpublish": "git push origin && git push origin -f --tags"
   },
   "dependencies": {
-    "memfs": "^3.4.12",
-    "webpack": "^5.61.0"
+    "memfs": "^3.4.12"
   },
   "devDependencies": {
     "c8": "^7.10.0",
@@ -57,6 +56,9 @@
     "prettier": "^2.4.1",
     "tap": "^16.0.0",
     "tsd": "^0.25.0"
+  },
+  "peerDependencies": {
+    "webpack": "^5.61.0"
   },
   "engines": {
     "node": ">= 12.13.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "pino-pretty": "^9.1.1",
     "prettier": "^2.4.1",
     "tap": "^16.0.0",
-    "tsd": "^0.25.0"
+    "tsd": "^0.25.0",
+    "webpack": "^5.75.0"
   },
   "peerDependencies": {
     "webpack": "^5.61.0"


### PR DESCRIPTION
<https://classic.yarnpkg.com/lang/en/docs/dependency-types/#toc-peerdependencies>

Workaround of a Yarn Berry behavior, which makes the Webpack instance of `pino-webpack-plugin` is different to one of the project: <https://github.com/yarnpkg/berry/issues/2401>.

```
/Volumes/Dev/OSS/unm-js/.yarn/__virtual__/webpack-virtual-76a0caa910/0/cache/webpack-npm-5.75.0-ebca50e2e7-2bcc5f3c19.zip/node_modules/webpack/lib/javascript/JavascriptModulesPlugin.js:143
                        throw new TypeError(
                        ^

TypeError: The 'compilation' argument must be an instance of Compilation
    at getCompilationHooks (/Volumes/Dev/OSS/unm-js/.yarn/__virtual__/webpack-virtual-76a0caa910/0/cache/webpack-npm-5.75.0-ebca50e2e7-2bcc5f3c19.zip/node_modules/webpack/lib/javascript/JavascriptModulesPlugin.js:143:10)
    at /Volumes/Dev/OSS/unm-js/.yarn/__virtual__/webpack-virtual-76a0caa910/0/cache/webpack-npm-5.75.0-ebca50e2e7-2bcc5f3c19.zip/node_modules/webpack/lib/javascript/CommonJsChunkFormatPlugin.js:43:19
    at Hook.eval [as call] (eval at create (/Volumes/Dev/OSS/unm-js/.yarn/cache/tapable-npm-2.2.1-8cf5ff3039-3b7a1b4d86.zip/node_modules/tapable/lib/HookCodeFactory.js:19:10), <anonymous>:7:1)
    at Hook.CALL_DELEGATE [as _call] (/Volumes/Dev/OSS/unm-js/.yarn/cache/tapable-npm-2.2.1-8cf5ff3039-3b7a1b4d86.zip/node_modules/tapable/lib/Hook.js:14:14)
    at Compiler.newCompilation (/Volumes/Dev/OSS/unm-js/.yarn/__virtual__/webpack-virtual-da9352bce3/0/cache/webpack-npm-5.75.0-ebca50e2e7-2bcc5f3c19.zip/node_modules/webpack/lib/Compiler.js:1121:30)
    at /Volumes/Dev/OSS/unm-js/.yarn/__virtual__/webpack-virtual-da9352bce3/0/cache/webpack-npm-5.75.0-ebca50e2e7-2bcc5f3c19.zip/node_modules/webpack/lib/Compiler.js:1166:29
    at Hook.eval [as callAsync] (eval at create (/Volumes/Dev/OSS/unm-js/.yarn/cache/tapable-npm-2.2.1-8cf5ff3039-3b7a1b4d86.zip/node_modules/tapable/lib/HookCodeFactory.js:33:10), <anonymous>:6:1)
    at Hook.CALL_ASYNC_DELEGATE [as _callAsync] (/Volumes/Dev/OSS/unm-js/.yarn/cache/tapable-npm-2.2.1-8cf5ff3039-3b7a1b4d86.zip/node_modules/tapable/lib/Hook.js:18:14)
    at Compiler.compile (/Volumes/Dev/OSS/unm-js/.yarn/__virtual__/webpack-virtual-da9352bce3/0/cache/webpack-npm-5.75.0-ebca50e2e7-2bcc5f3c19.zip/node_modules/webpack/lib/Compiler.js:1161:28)
    at /Volumes/Dev/OSS/unm-js/.yarn/__virtual__/webpack-virtual-da9352bce3/0/cache/webpack-npm-5.75.0-ebca50e2e7-2bcc5f3c19.zip/node_modules/webpack/lib/Compiler.js:524:12

Node.js v19.1.0
```

[Other projects also do this.](https://github.com/jantimon/html-webpack-plugin/blob/main/package.json#L59)