### PR TITLE
Support bundling on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,12 +3,16 @@ name: CI
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       matrix:
         node-version: [14.x, 16.x, 18.x]
+        os: [ubuntu-latest, windows-latest]
+        exclude:
+          - os: windows-latest
+            node-version: 14.x
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,7 +24,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('package.json') }}
+          key: node-modules-${{ matrix.os }}-${{ hashFiles('package.json') }}
       - name: Install dependencies
         run: npm install
       - name: Run Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x]
         os: [ubuntu-latest, windows-latest]
-        exclude:
-          - os: windows-latest
-            node-version: 14.x
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const webpack = require('webpack')
 const CommonJsRequireDependency = require('webpack/lib/dependencies/CommonJsRequireDependency')
 const { createFsFromVolume, Volume } = require('memfs')
-const { sep, dirname, relative } = require('path')
+const { join, dirname, relative } = require('path')
 // const { cache } = require('webpack') // Cache handling missing
 
 const fileBanner = `/* Start of pino-webpack-plugin additions */
@@ -24,6 +24,10 @@ const PLUGIN_NAME = 'PinoWebpackPlugin'
 // const CACHE_ID = 'pino-worker-plugin' // Cache handling missing
 
 const fs = createFsFromVolume(new Volume())
+
+function quote(path) {
+  return `'${path.replace(/([\\'])/g, '\\$1')}'`
+}
 
 class PinoWebpackPlugin {
   constructor(options) {
@@ -164,7 +168,7 @@ class PinoWebpackPlugin {
                   fileBanner,
                   '\n',
                   `globalThis.__bundlerPathsOverrides = {${dependenciesFiles.map(
-                    ([workerId, file]) => `'${workerId}': pinoWebpackAbsolutePath('${relativePath}${sep}${file}')`
+                    ([workerId, file]) => `'${workerId}': pinoWebpackAbsolutePath(${quote(join(relativePath, file))})`
                   )}};`,
                   '\n',
                   '/* End of pino-webpack-plugin additions */',

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -95,14 +95,18 @@ function createTests(tapInstance, webpackConfig, distFolder) {
       const fileContent = readFileSync(resolve(distFolder, filePath), 'utf-8')
       // Test if the file starts with the expected banner
       tapInstance.ok(fileContent.startsWith(banner), `${basename(filePath)} should starts with banner`)
+      const quoteRegex = (path) => `'${path.replace(/\\/g, '\\\\\\\\')}'`
       for (const dependencyKey in dependencies) {
-        // For each dependency, test if the expeted file is in the __bundlerPathsOverrides object
+        // For each dependency, test if the expected file is in the __bundlerPathsOverrides object
         const dependencyRegexp = new RegExp(
-          `globalThis\\.__bundlerPathsOverrides = \\{.*?'${dependencyKey}': pinoWebpackAbsolutePath\\('${
-            (relative(dirname(filePath), dirname(dependencies[dependencyKey])) || '.') +
-            '/' +
-            dependencies[dependencyKey]
-          }'\\).*?\\}`
+          `globalThis\\.__bundlerPathsOverrides = \\{.*?'${dependencyKey}': pinoWebpackAbsolutePath\\(${
+            quoteRegex(
+              join(
+                relative(dirname(filePath), dirname(dependencies[dependencyKey])),
+                dependencies[dependencyKey]
+              )
+            )
+          }\\).*?\\}`
         )
         tapInstance.ok(fileContent.match(dependencyRegexp), `${dependencyKey} should have correct path in ${filePath}`)
       }


### PR DESCRIPTION
Current implementation of the plugin generates invalid paths on windows:
```js
globalThis.__bundlerPathsOverrides = {'pino/file': pinoWebpackAbsolutePath('.\path.js')...
```
instead of escaped paths:
```js
globalThis.__bundlerPathsOverrides = {'pino/file': pinoWebpackAbsolutePath('.\\path.js')...
```
This PR should fix this problem.
(similar to #102)
